### PR TITLE
Code fix for EntityExistsException

### DIFF
--- a/src/main/java/com/javatechie/jpa/entity/Product.java
+++ b/src/main/java/com/javatechie/jpa/entity/Product.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
 
 @Data
 @AllArgsConstructor
@@ -15,6 +16,7 @@ import javax.persistence.Id;
 @Entity
 public class Product {
     @Id
+    @GeneratedValue
     private int pid;
     private String productName;
     private int qty;


### PR DESCRIPTION
Hi there,

I encountered an issue while working on the open source project. When attempting to persist a new 'Product' entity, I received the following exception:

A different object with the same identifier value was already associated with the session : [com.javatechie.jpa.entity.Product#0]; nested exception is javax.persistence.EntityExistsException: A different object with the same identifier value was already associated with the session : [com.javatechie.jpa.entity.Product#0]

This error occurs when attempting to persist an entity with a primary key value that already exists in the Hibernate session. The error message suggests that the 'Product' entity with primary key value '0' has already been associated with the session.

To resolve this issue, I ensured that each 'Product' entity has a unique primary key value before persisting it. I also verified that the primary key values are generated or assigned in a way that guarantees uniqueness across all entities in the 'Product' table.

If there are any further questions or concerns, please let me know.